### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -38,11 +38,14 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;
         }
+        return "Login failed: risky variable is null";
     }
 
     @GetMapping("/process")


### PR DESCRIPTION
This PR addresses a NullPointerException that occurred in the `login` method of `DemoController`. The issue was caused by the `risky` variable being null, leading to an exception when `toString()` was called. The fix implements a null check for the variable to prevent this exception. 

**Root Cause Analysis:** 
- The `risky` variable was declared but not initialized, causing it to be null when accessed. 

**Code Changes:** 
- Added a null check for the `risky` variable before calling `toString()`.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java