### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -38,7 +38,11 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                return null; // Handle null case
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
This PR addresses a NullPointerException that occurred in the login method of DemoController. The issue was caused by attempting to call toString() on a null variable. A null check has been added to prevent this error. 

**RCA**: The NullPointerException was caused by the variable 'risky' being null when accessed.
**Fix**: Added a null check before accessing the variable.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java