### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -38,7 +36,12 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                log.error("Risky variable is null for user {}", username);
+                return "Error: risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
## Root Cause Analysis
The incident was caused by a NullPointerException in the `login` method of `DemoController`. The variable `risky` was found to be null, leading to the exception when attempting to invoke `.toString()`. 

## Fix Details
Added defensive null checking to prevent the exception from occurring. The code now checks if the variable is null before invoking any methods on it.

## Changes Made
- Updated the `login` method to include a null check for `risky`.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java