### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -37,12 +35,10 @@ public class DemoController {
         log.info("Login attempt with username: {}", username);
 
         String risky = null;
-        try {
+        if (risky != null) {
             return risky.toString();
-        } catch (NullPointerException e) {
-            log.error("Simulated NPE during login for user {}", username, e);
-            throw e;
         }
+        return "Risky is null"; // Handle null case
     }
 
     @GetMapping("/process")


### PR DESCRIPTION
### Root Cause Analysis
The NullPointerException occurred in the `login` method of `DemoController` when trying to call `toString()` on a null variable `risky`. This resulted in an application crash.

### Fix Details
Added a null check for the variable `risky` to prevent the NullPointerException. 

### Code Changes
- Defensive programming added to ensure `risky` is not null before invoking methods on it.

### Related Issue
[INC-NullPointerException-P1-20250915](https://github.com/grrakesh/OpsMindJava/issues/1)\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java