### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,17 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
 
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -28,20 +25,19 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
 
     @PostMapping("/login")
     public String login(@RequestParam String username, @RequestParam String password) {
         log.info("Login attempt with username: {}", username);
-
         String risky = null;
-        try {
+        // Added null check to prevent NPE
+        if (risky != null) {
             return risky.toString();
-        } catch (NullPointerException e) {
-            log.error("Simulated NPE during login for user {}", username, e);
-            throw e;
+        } else {
+            log.warn("Risky variable is null for user {}", username);
+            return "Invalid operation";
         }
     }
 


### PR DESCRIPTION
### Root Cause Analysis:
The application encountered a NullPointerException due to a null reference on the variable `risky` in the `login` method of the `DemoController` class. 

### Fix Details:
Added a null check for the `risky` variable to prevent the NullPointerException from occurring. This ensures that the application can handle cases where `risky` is null without throwing an exception.

### Changes Made:
- Added null check for `risky` variable in `login` method.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java