### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,17 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
 
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -28,17 +25,20 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
 
     @PostMapping("/login")
     public String login(@RequestParam String username, @RequestParam String password) {
         log.info("Login attempt with username: {}", username);
-
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                log.error("Risky variable is null for user: {}", username);
+                return "Error: risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis:
The `login` method in `DemoController` was throwing a NullPointerException because it attempted to call `toString()` on a variable (`risky`) that was null. This has been fixed by adding a null check before the method call.

### Code Changes:
- Added a null check for the `risky` variable before calling `toString()`.

### Impact:
This change prevents the NullPointerException and ensures the application handles null variables gracefully.

### Related Incident:
- Incident ID: INC-NullPointerException-P1-20250915\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java