### PR TITLE
Fix NullPointerException in DemoController login method

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -37,11 +37,11 @@ public class DemoController {
         log.info("Login attempt with username: {}", username);
 
         String risky = null;
-        try {
+        if (risky != null) {
             return risky.toString();
-        } catch (NullPointerException e) {
-            log.error("Simulated NPE during login for user {}", username, e);
-            throw e;
+        } else {
+            log.error("Risky variable is null for user {}", username);
+            return "Error: risky variable is null";
         }
     }
 


### PR DESCRIPTION
This PR fixes a NullPointerException occurring in the login method of DemoController. The issue was due to the 'risky' variable being null. A defensive check has been added to prevent the exception. 

**Root Cause Analysis:**
- The NPE occurred because the `risky` variable was null when attempting to call `toString()` on it.

**Fix Details:**
- Added null check for the `risky` variable before invoking any methods on it.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java