### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -38,7 +36,11 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                return "risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
This PR addresses a NullPointerException encountered in the `login` method of `DemoController`. The exception was caused by attempting to call `toString()` on a null variable `risky`. The fix adds a null check to prevent this issue, ensuring that the method runs smoothly without throwing an exception.

**Root Cause Analysis:**
- The `risky` variable was null at the time of invocation of `toString()`, leading to a `NullPointerException`.

**Fix Details:**
- Added a null check for the `risky` variable before calling `toString()`.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java