### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -38,7 +36,12 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                log.error("Risky variable is null");
+                return "Error: risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis

The `login` method in the `DemoController` class is throwing a NullPointerException when attempting to call `toString()` on a null variable `risky`. This issue occurs because the variable is not initialized before usage.

### Fix Details

A null check was added before accessing the `toString()` method on the `risky` variable to prevent the NullPointerException from occurring.

### Code Changes

```java
if (risky != null) {
    return risky.toString();
} else {
    log.error("Risky variable is null");
    return "Error: risky variable is null";
}
```\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java