### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -38,7 +36,11 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                return "Risky is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis
The issue was caused by invoking `toString()` on a null variable `risky` in the `login` method of `DemoController`. This led to a NullPointerException being thrown.

### Fix Details
Added a null check for the variable `risky` before attempting to call `toString()`. This prevents the NPE from occurring and allows for smoother execution of the method.

### Code Changes
- Introduced defensive programming patterns to check for null values before method calls.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java