### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -37,11 +35,11 @@ public class DemoController {
         log.info("Login attempt with username: {}", username);
 
         String risky = null;
-        try {
+        if (risky != null) {
             return risky.toString();
-        } catch (NullPointerException e) {
-            log.error("Simulated NPE during login for user {}", username, e);
-            throw e;
+        } else {
+            log.warn("risky variable is null. Returning default message.");
+            return "Default message";
         }
     }
 


### PR DESCRIPTION
This pull request addresses a NullPointerException issue in the `DemoController` class, specifically in the `login` method. The issue occurred due to an attempt to invoke `toString()` on a null object. The fix includes a null check for the variable `risky` to prevent the exception. 

### Root Cause Analysis:
The `risky` variable was null, leading to the NullPointerException when calling `risky.toString()`. 

### Changes Made:
- Added a null check for the `risky` variable to prevent the NPE. 

This is a defensive programming approach to ensure that the code does not throw an exception if `risky` is null.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java