### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -38,7 +38,9 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis
The NullPointerException occurs in the `login` method when attempting to invoke `toString()` on a null variable `risky`.

### Fix Details
Added a defensive null check before calling `toString()` on the `risky` variable to prevent the NullPointerException from occurring.

### Changes Made
- Added null check on the `risky` variable in the `login` method.

### Related Incident
- Incident ID: INC-20250922195658\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java