### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -38,7 +36,11 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                return "Risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis
The `NullPointerException` was occurring in the `login` method of `DemoController` when trying to invoke `toString()` on a null variable `risky`. This was causing application failures during user login attempts.

### Fix Details
Added defensive null checking to prevent `NullPointerException` by ensuring that the variable is not null before accessing its methods.

### Code Changes
- Added null check for `risky` in the `login` method.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java