### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,17 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
 
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -28,17 +25,18 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
 
     @PostMapping("/login")
     public String login(@RequestParam String username, @RequestParam String password) {
         log.info("Login attempt with username: {}", username);
-
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            }
+            return "Risky is null!"; // or handle accordingly
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis
The NullPointerException occurs in the `login` method of `DemoController` when the variable `risky` is null and `toString()` is called on it.

### Fix Details
Added a null check before invoking `toString()` on the `risky` variable to prevent the exception and improve application stability.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java