### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,17 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
 
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -28,7 +25,6 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
 
@@ -37,11 +33,11 @@ public class DemoController {
         log.info("Login attempt with username: {}", username);
 
         String risky = null;
-        try {
+        if (risky != null) {
             return risky.toString();
-        } catch (NullPointerException e) {
-            log.error("Simulated NPE during login for user {}", username, e);
-            throw e;
+        } else {
+            log.warn("Risky variable is null for user: {}", username);
+            return "Risky variable is null";
         }
     }
 


### PR DESCRIPTION
### Root Cause Analysis:
The NullPointerException occurred in the `login` method of the `DemoController` class due to a call to `risky.toString()` where `risky` is null.

### Fix Details:
Added a null check for the variable `risky` to prevent the NullPointerException from being thrown and ensure graceful handling of null values.

### Code Changes:
- Added a null check before invoking the `toString()` method on `risky`.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java