### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,12 +9,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -38,7 +36,12 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                log.error("Risky variable is null for user {}", username);
+                return "Risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis
The application was encountering a `NullPointerException` in the `login` method of the `DemoController`. This was due to the `risky` variable being null, which caused the application to attempt to call `toString()` on a null reference.

### Fix Details
The fix involves adding a null check for the `risky` variable to prevent the `NullPointerException` and ensure that the method can handle null values gracefully.

### Code Changes
The following changes were made:
- Added a null check before attempting to call methods on the `risky` variable to prevent `NullPointerException`.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java