### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -26,7 +26,7 @@ public class DemoController {
             s.length();
         } catch (NullPointerException e) {
             log.error("Caught NullPointerException in /hello endpoint", e);
-            throw e; // rethrow so that it’s still visible as an error
+            throw e; // rethrow so that itu2019s still visible as an error
         }
 
         return "Hello from Spring Boot!";
@@ -37,11 +37,11 @@ public class DemoController {
         log.info("Login attempt with username: {}", username);
 
         String risky = null;
-        try {
+        if (risky != null) {
             return risky.toString();
-        } catch (NullPointerException e) {
-            log.error("Simulated NPE during login for user {}", username, e);
-            throw e;
+        } else {
+            log.error("risky is null for user {}", username);
+            return "Failed to login: risky is null";
         }
     }
 


### PR DESCRIPTION
This PR fixes a NullPointerException that occurred in the login method of DemoController. The root cause was that the variable 'risky' was null. A null check has been added to prevent this exception.

### Root Cause Analysis:
- **Error**: Cannot invoke "String.toString()" because "risky" is null.
- **Fix**: Added null check before accessing 'risky'.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java