### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
@@ -38,7 +37,7 @@ public class DemoController {
 
         String risky = null;
         try {
-            return risky.toString();
+            return risky != null ? risky.toString() : "default value";
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
### Root Cause Analysis:
The `NullPointerException` occurred in the `login` method of the `DemoController` due to an attempt to call `toString()` on a null variable `risky`. This has been corrected by adding a null check before invoking `toString()`.

### Fix Details:
- Added a check to ensure `risky` is not null before calling `toString()`. 
- If `risky` is null, it returns a default value to avoid the exception.

This change prevents the server from throwing a `NullPointerException` and improves the robustness of the login functionality.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java