### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -1,5 +1,4 @@
 package com.ai.mind.ops;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -8,18 +7,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -28,23 +22,24 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
-
     @PostMapping("/login")
     public String login(@RequestParam String username, @RequestParam String password) {
         log.info("Login attempt with username: {}", username);
-
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                log.warn("Risky is null for user {}", username);
+                return "Risky variable is null";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;
         }
     }
-
     @GetMapping("/process")
     public ResponseEntity<String> process(@RequestParam double amount,
                                           @RequestParam(defaultValue = "false") boolean simulateFix) {


### PR DESCRIPTION
## Root Cause Analysis:
The NullPointerException occurred in the `login` method of the `DemoController` class. The error was caused by trying to invoke `toString()` on a null variable `risky`.

## Fix:
Added a null check for the `risky` variable to prevent the NullPointerException and ensure the application continues to function properly if the variable is null.

## Changes:
- Added a check for null before accessing the `risky` variable in the `login` method.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java