### PR TITLE
Fix NullPointerException in DemoController.login()

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -9,17 +9,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
 
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -28,17 +25,20 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
 
     @PostMapping("/login")
     public String login(@RequestParam String username, @RequestParam String password) {
         log.info("Login attempt with username: {}", username);
-
         String risky = null;
         try {
-            return risky.toString();
+            if (risky != null) {
+                return risky.toString();
+            } else {
+                log.warn("Risky variable is null for user {}", username);
+                return "Risky variable is not initialized.";
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
             throw e;


### PR DESCRIPTION
This PR addresses the NullPointerException issue that occurs in the login method of the DemoController when the 'risky' variable is null. A defensive null check has been added to prevent the exception from occurring.

**Root Cause Analysis**:
The error occurred because the 'risky' variable was not initialized before invoking the toString() method.

**Fix Details**:
- Added a null check for the 'risky' variable to prevent the NullPointerException.

This change ensures that the application does not crash due to this error and provides a more robust handling of null values.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java