### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -12,17 +12,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
 
-
     @GetMapping("/hello")
     public String hello() {
         log.error("/api/hello called");
-
         try {
             String s = null;
             // This will throw a NullPointerException
@@ -31,7 +28,6 @@ public class DemoController {
             log.error("Caught NullPointerException in /hello endpoint", e);
             throw e; // rethrow so that it’s still visible as an error
         }
-
         return "Hello from Spring Boot!";
     }
 
@@ -39,20 +35,22 @@ public class DemoController {
     public ResponseEntity<Map<String, Object>> login(
             @RequestParam String username,
             @RequestParam String password) {
-
         log.info("Login attempt with username: {}", username);
-
         String risky = null;
         Map<String, Object> response = new HashMap<>();
-
         try {
-            return ResponseEntity.ok(Map.of(
-                    "status", "success",
-                    "message", risky.toString()
-            ));
+            if (risky != null) {
+                return ResponseEntity.ok(Map.of(
+                        "status", "success",
+                        "message", risky.toString()
+                ));
+            } else {
+                response.put("status", "error");
+                response.put("message", "risky is null");
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
-
             response.put("status", "error");
             response.put("message", "NullPointerException occurred");
             response.put("details", e.toString());


### PR DESCRIPTION
This pull request addresses and fixes a NullPointerException in the `login` method of the `DemoController` class. The issue occurred because the variable `risky` was null when attempting to call `toString()`. A defensive check has been added to ensure that this does not happen again.

### Root Cause Analysis
The original code attempted to call `toString()` on a null variable, leading to a NullPointerException. The fix adds a null check before the method call.

### Code Changes
- Added null check for the `risky` variable before using it.

This should help prevent future occurrences of this error.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java