### PR TITLE
Fix for NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -12,12 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -46,10 +44,16 @@ public class DemoController {
         Map<String, Object> response = new HashMap<>();
 
         try {
-            return ResponseEntity.ok(Map.of(
-                    "status", "success",
-                    "message", risky.toString()
-            ));
+            if (risky != null) {
+                return ResponseEntity.ok(Map.of(
+                        "status", "success",
+                        "message", risky.toString()
+                ));
+            } else {
+                response.put("status", "error");
+                response.put("message", "risky was null");
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
 


### PR DESCRIPTION
This pull request addresses a NullPointerException that occurs in the login method of the DemoController class. The issue arises due to a null reference being used to call the toString() method on the 'risky' variable. A defensive null check has been added to prevent this exception.

**Root Cause Analysis:** The NullPointerException is caused when trying to call `risky.toString()` where `risky` is null.

**Fix Details:** Added a check to ensure 'risky' is not null before invoking methods on it. This fix prevents the application from throwing an exception and allows it to handle the null case appropriately.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java