### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -46,10 +46,16 @@ public class DemoController {
         Map<String, Object> response = new HashMap<>();
 
         try {
-            return ResponseEntity.ok(Map.of(
-                    "status", "success",
-                    "message", risky.toString()
-            ));
+            if (risky != null) {
+                return ResponseEntity.ok(Map.of(
+                        "status", "success",
+                        "message", risky.toString()
+                ));
+            } else {
+                response.put("status", "error");
+                response.put("message", "risky variable is null");
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
 


### PR DESCRIPTION
This pull request addresses the NullPointerException that occurs in the login method of DemoController when accessing the 'risky' variable. A null check has been added to prevent the exception. Root Cause: The variable 'risky' was null, which caused a NullPointerException when calling risky.toString(). Fix applied: Added a check for null before accessing the variable.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java