### PR TITLE
Fix NullPointerException in DemoController

### DIFF
--- a/src/main/java/com/ai/mind/ops/DemoController.java
+++ b/src/main/java/com/ai/mind/ops/DemoController.java
@@ -12,12 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RestController
 @RequestMapping("/api")
 public class DemoController {
     private static final Logger log = LoggerFactory.getLogger(DemoController.class);
-
 
     @GetMapping("/hello")
     public String hello() {
@@ -46,10 +44,16 @@ public class DemoController {
         Map<String, Object> response = new HashMap<>();
 
         try {
-            return ResponseEntity.ok(Map.of(
-                    "status", "success",
-                    "message", risky.toString()
-            ));
+            if (risky != null) {
+                return ResponseEntity.ok(Map.of(
+                        "status", "success",
+                        "message", risky.toString()
+                ));
+            } else {
+                response.put("status", "error");
+                response.put("message", "risky variable is null");
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+            }
         } catch (NullPointerException e) {
             log.error("Simulated NPE during login for user {}", username, e);
 


### PR DESCRIPTION
This PR addresses a NullPointerException occurring in the `login` method of the `DemoController`. The issue arises when attempting to call `toString()` on a null variable `risky`. The fix implements a null check to avoid the exception and ensure the application functions correctly. 

**RCA:** The NPE was caused by a null reference being dereferenced.

**Fix:** Added a null check before attempting to call `toString()` on the variable `risky`.\n\n**Files Modified:**\n- src/main/java/com/ai/mind/ops/DemoController.java